### PR TITLE
Fix asynchronous count in search helper

### DIFF
--- a/WebApi/SimpleAuthNet/Tools/SearchResultsHelper.cs
+++ b/WebApi/SimpleAuthNet/Tools/SearchResultsHelper.cs
@@ -28,7 +28,7 @@ public class SearchResultsHelper
     public static async Task<ApiSearchResults<T>> GetApiSearchResultsAsync<T>(IQueryable<T> query, int pageSize,
         int pageIndex, string orderByField, bool orderAscending = true)
     {
-        var totalCount = query.Count();
+        var totalCount = await query.CountAsync();
         var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
 
         IList<T> results = await query.OrderByField(orderByField, orderAscending)


### PR DESCRIPTION
## Summary
- fix `SearchResultsHelper.GetApiSearchResultsAsync` to use `CountAsync`

## Testing
- `dotnet build WebApi/WebApi.sln` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68504f8e527c8321ae1a76971cc3ed66